### PR TITLE
feat!: make popup accept any widget as the body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "ratatui"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb12f8fbf6c62614b0d56eb352af54f6a22410c3b079eb53ee93c7b97dd31d8"
+checksum = "a564a852040e82671dc50a37d88f3aa83bbc690dfc6844cfe7a2591620206a80"
 dependencies = [
  "bitflags 2.4.1",
  "cassowary",
@@ -577,12 +577,12 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "stability"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.43",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 derive-getters = "0.3.0"
 derive_setters = "0.1.6"
-ratatui = "0.26.1"
+ratatui = { version = "0.26.2", features = ["unstable-widget-ref"] }
 
 [dev-dependencies]
 color-eyre = "0.6.3"

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ use tui_popup::Popup;
 fn render_popup(frame: &mut Frame) {
     let popup = Popup::new("tui-popup demo", "Press any key to exit")
        .style(Style::new().white().on_blue());
-    frame.render_widget(popup.to_widget(), frame.size());
+    frame.render_widget(&popup, frame.size());
 }
 ```
 
-<!-- cargo-rdme end -->
+![demo](https://vhs.charm.sh/vhs-q5Kz0QP3zmrBlQ6dofjMh.gif)
 
-![demo](./examples/demo.png)
+<!-- cargo-rdme end -->
 
 ## State
 
@@ -42,7 +42,7 @@ use tui_popup::Popup;
 fn render_stateful_popup(frame: &mut Frame, popup_state: &mut PopupState) {
     let popup = Popup::new("tui-popup demo", "Press any key to exit")
        .style(Style::new().white().on_blue());
-    frame.render_stateful_widget(popup.to_widget(), frame.size(), popup_state);
+    frame.render_stateful_widget_ref(popup, frame.size(), popup_state);
 }
 
 fn move_up(popup_state: &mut PopupState) {
@@ -74,7 +74,27 @@ match event.read()? {
 }
 ```
 
-![state demo](./examples/state.gif)
+![state demo](https://vhs.charm.sh/vhs-73faTQbCkAHOv7dt0MQJAd.gif)
+
+The popup also supports rendering arbitrary widgets by implementing SizedWidgetRef (or wrapping them
+with the provided SizedWrapper). This makes it possible to support wrapping and scrolling in using a
+`Paragraph` widget, or scrolling any amount of widgets using
+[tui-scrollview](https://github.com/joshka/tui-scrollview/).
+
+```rust
+let lines: Text = (0..10).map(|i| Span::raw(format!("Line {}", i))).collect();
+let paragraph = Paragraph::new(lines).scroll((scroll, 0));
+let sized_paragraph = SizedWrapper {
+    inner: paragraph,
+    width: 21,
+    height: 5,
+};
+let popup = Popup::new("scroll: ↑/↓ quit: Esc", sized_paragraph)
+    .style(Style::new().white().on_blue());
+frame.render_widget_ref(popup, area);
+```
+
+![paragraph example](https://vhs.charm.sh/vhs-A3mwcn9IngIc0hpl2AsXM.gif)
 
 ## Features
 

--- a/examples/demo.gif
+++ b/examples/demo.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5a9c7e9f93542efe756cbc88e4a1dfad58b582aec33d30675e4d05d2ace5136
-size 209884

--- a/examples/demo.png
+++ b/examples/demo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7f32fb4b95e744432a8b2a737864750b29893aa688acc8a8c1fb1b8d5200c64
-size 198525

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -27,7 +27,7 @@ fn main() -> color_eyre::Result<()> {
 
         let popup = Popup::new("tui-popup demo", "Press any key to exit")
             .style(Style::new().white().on_blue());
-        frame.render_widget(popup.to_widget(), area);
+        frame.render_widget_ref(popup, area);
     })?;
     while !matches!(event::read()?, Event::Key(_)) {}
     restore_terminal()?;

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -1,0 +1,67 @@
+/// Demonstrates how to use the `Popup` widget with a `Paragraph` as the body.
+use std::io::stdout;
+
+use crossterm::{
+    event::{self, Event},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen},
+    ExecutableCommand,
+};
+use lipsum::lipsum;
+use ratatui::{
+    prelude::*,
+    widgets::{Paragraph, Wrap},
+};
+use tui_popup::{Popup, SizedWrapper};
+
+fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+    let mut terminal = init_terminal()?;
+
+    let mut scroll = 0;
+    loop {
+        terminal.draw(|frame| {
+            let area = frame.size();
+
+            let lorem_ipsum = lipsum(area.area() as usize / 5);
+            let background = Paragraph::new(lorem_ipsum)
+                .wrap(Wrap { trim: false })
+                .dark_gray();
+            frame.render_widget(background, area);
+            let lines: Text = (0..10).map(|i| Span::raw(format!("Line {}", i))).collect();
+            let paragraph = Paragraph::new(lines).scroll((scroll, 0));
+            let sized_paragraph = SizedWrapper {
+                inner: paragraph,
+                width: 21,
+                height: 5,
+            };
+            let popup = Popup::new("scroll: ↑/↓ quit: Esc", sized_paragraph)
+                .style(Style::new().white().on_blue());
+            frame.render_widget_ref(popup, area);
+        })?;
+        use crossterm::event::KeyCode::*;
+        match event::read()? {
+            Event::Key(key) => match key.code {
+                Char('q') | Esc => break,
+                Char('j') | Down => scroll = scroll.saturating_add(1),
+                Char('k') | Up => scroll = scroll.saturating_sub(1),
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    restore_terminal()?;
+    Ok(())
+}
+
+fn init_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>, color_eyre::eyre::Error> {
+    stdout().execute(EnterAlternateScreen)?;
+    let terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+    enable_raw_mode()?;
+    Ok(terminal)
+}
+
+fn restore_terminal() -> Result<(), color_eyre::eyre::Error> {
+    disable_raw_mode()?;
+    stdout().execute(crossterm::terminal::LeaveAlternateScreen)?;
+    Ok(())
+}

--- a/examples/paragraph.tape
+++ b/examples/paragraph.tape
@@ -1,13 +1,15 @@
 # A VHS tape. See https://github.com/charmbracelet/vhs
-Output "target/demo.gif"
+Output "target/paragraph.gif"
 Set Theme "Aardvark Blue"
 Set Width 800
 Set Height 600
 Hide
-Type "cargo run --example demo" Enter
-Sleep 2s
+Type "cargo run --example paragraph" Enter
+Sleep 4s
 Show
-Screenshot "target/demo.png"
+Down@100ms 10
+Sleep 1s
+Up@100ms 10
 Sleep 1s
 Hide
-Space
+Type "q"

--- a/examples/state.gif
+++ b/examples/state.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5730316b5f32318a1d66d08d1fa350dc3c492cf231597b593adc7e392137697
-size 1696416

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -50,7 +50,7 @@ fn render(frame: &mut Frame<'_>, popup_state: &mut PopupState) {
         "l: move right".into(),
     ]);
     let popup = Popup::new("Popup", body).style(Style::new().white().on_blue());
-    frame.render_stateful_widget(popup.to_widget(), background_area, popup_state);
+    frame.render_stateful_widget_ref(popup, background_area, popup_state);
     let text = format!("{area:?}", area = popup_state.area());
     let status = Paragraph::new(text).style(Style::new().white().on_black());
     frame.render_widget(status, status_area);

--- a/examples/state.tape
+++ b/examples/state.tape
@@ -1,5 +1,5 @@
 # A VHS tape. See https://github.com/charmbracelet/vhs
-Output "state.gif"
+Output "target/state.gif"
 Set Theme "Aardvark Blue"
 Set Width 800
 Set Height 600

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,15 @@
 //! fn render_popup(frame: &mut Frame) {
 //!     let popup = Popup::new("tui-popup demo", "Press any key to exit")
 //!        .style(Style::new().white().on_blue());
-//!     frame.render_widget(popup.to_widget(), frame.size());
+//!     frame.render_widget(&popup, frame.size());
 //! }
 //! ```
+//!
+//! ![demo](https://vhs.charm.sh/vhs-q5Kz0QP3zmrBlQ6dofjMh.gif)
 
 mod popup;
 mod state;
 mod widget;
 
-pub use popup::Popup;
-pub use state::PopupState;
-pub use widget::PopupWidget;
+pub use popup::*;
+pub use state::*;


### PR DESCRIPTION
Popup is now a generic over the body widget, allowing for more complex
widgets to be used as the body of the popup. This change also allows for
the popup to be rendered multiple times without needing to clone it.

Fixes: https://github.com/joshka/tui-popup/issues/16

BREAKING CHANGE: The Popup widget now accepts any widget as the body
instead of just a Text. This allows for more complex widgets to be used
as the body of the popup, such as Paragraph or ScrollView.

Additionally the Popup widget now implements `WidgetRef` and
`StatefulWidgetRef` instead of having a separate PopupWidget type. This
allows for saving a reference to the popup and rendering it multiple
times without needing to clone it. To update your code, replace
`frame.render_widget(popup.to_widget(), area)` with
`frame.render_widget(&popup, area)` and replace
`frame.render_stateful_widget(popup.to_widget(), area, state)`
with `frame.render_stateful_widget_ref(&popup, area, state)`.
