### PR TITLE
feat: allow setting borders

### DIFF
--- a/src/popup.rs
+++ b/src/popup.rs
@@ -1,7 +1,10 @@
 use std::fmt::Debug;
 
 use derive_setters::Setters;
-use ratatui::{prelude::*, widgets::WidgetRef};
+use ratatui::{
+    prelude::*,
+    widgets::{Borders, WidgetRef},
+};
 
 /// Configuration for a popup.
 ///
@@ -31,6 +34,8 @@ pub struct Popup<'content, W: SizedWidgetRef> {
     pub title: Line<'content>,
     /// The style to apply to the entire popup.
     pub style: Style,
+    /// The borders of the popup.
+    pub borders: Borders,
 }
 
 /// A trait for widgets that have a fixed size.
@@ -45,7 +50,7 @@ pub trait SizedWidgetRef: WidgetRef + Debug {
 }
 
 impl<'content, W: SizedWidgetRef> Popup<'content, W> {
-    /// Create a new popup with the given title and body.
+    /// Create a new popup with the given title and body with all the borders.
     ///
     /// # Parameters
     ///
@@ -69,6 +74,7 @@ impl<'content, W: SizedWidgetRef> Popup<'content, W> {
             body,
             title: title.into(),
             style: Style::default(),
+            borders: Borders::ALL,
         }
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -27,16 +27,21 @@ impl<W: SizedWidgetRef> StatefulWidgetRef for Popup<'_, W> {
 
             Rect::new(x, y, width, height)
         } else {
+            let border_height = self.borders.intersects(Borders::TOP) as usize
+                + self.borders.intersects(Borders::BOTTOM) as usize;
+            let border_width = self.borders.intersects(Borders::LEFT) as usize
+                + self.borders.intersects(Borders::RIGHT) as usize;
+
             let height = self
                 .body
                 .height()
-                .saturating_add(2)
+                .saturating_add(border_height)
                 .try_into()
                 .unwrap_or(area.height);
             let width = self
                 .body
                 .width()
-                .saturating_add(2)
+                .saturating_add(border_width)
                 .try_into()
                 .unwrap_or(area.width);
             centered_rect(width, height, area)
@@ -46,7 +51,7 @@ impl<W: SizedWidgetRef> StatefulWidgetRef for Popup<'_, W> {
 
         Clear.render(area, buf);
         let block = Block::default()
-            .borders(Borders::ALL)
+            .borders(self.borders)
             .title(self.title.clone())
             .style(self.style);
         block.render_ref(area, buf);


### PR DESCRIPTION
This PR allows users to set borders and title alignment. This is a backward compatible change.

My use case is to hide the left and right border to make copy & paste from a popup that is as wide as the terminal easier.

![image](https://github.com/joshka/tui-popup/assets/18085551/3aa2b6b2-0654-4b2d-8164-b441b0de54e6)
