### PR TITLE
chore(examples): simplify examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,6 @@ name = "tui-popup"
 version = "0.3.3"
 dependencies = [
  "color-eyre",
- "crossterm",
  "derive-getters",
  "derive_setters",
  "lipsum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ ratatui = { version = "0.27.0", features = ["unstable-widget-ref"] }
 
 [dev-dependencies]
 color-eyre = "0.6.3"
-crossterm = "0.27.0"
 lipsum = "0.9.1"
 
 [lints.clippy]

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -1,110 +1,113 @@
-use std::{io::stdout, ops::ControlFlow};
-
-use crossterm::{
-    event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
-        MouseButton,
-    },
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-    ExecutableCommand,
-};
+use color_eyre::Result;
 use lipsum::lipsum;
 use ratatui::{
-    prelude::*,
+    crossterm::event::{
+        self, Event, KeyCode, KeyEvent, KeyEventKind, MouseButton, MouseEvent, MouseEventKind,
+    },
+    prelude::{Constraint, Frame, Layout, Rect, Style, Stylize, Text},
     widgets::{Paragraph, Wrap},
 };
 use tui_popup::{Popup, PopupState};
 
-fn main() -> color_eyre::Result<()> {
-    color_eyre::install()?;
-    let mut terminal = init_terminal()?;
-    let mut popup_state = PopupState::default();
-    loop {
-        terminal.draw(|frame| render(frame, &mut popup_state))?;
-        if handle_events(&mut popup_state)?.is_break() {
-            break;
+mod terminal;
+
+fn main() -> Result<()> {
+    let mut terminal = terminal::init()?;
+    let mut app = App::default();
+    while !app.should_exit {
+        terminal.draw(|frame| app.render(frame))?;
+        app.handle_events()?;
+    }
+    terminal::restore()?;
+    Ok(())
+}
+
+#[derive(Default)]
+struct App {
+    popup: PopupState,
+    should_exit: bool,
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let [background_area, status_area] =
+            Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(frame.size());
+
+        let background = Self::background(background_area);
+        frame.render_widget(background, background_area);
+
+        let popup = Self::popup_widget();
+        frame.render_stateful_widget_ref(popup, background_area, &mut self.popup);
+
+        // must be called after rendering the popup widget as it relies on the popup area being set
+        let status_bar = self.status_bar();
+        frame.render_widget(status_bar, status_area);
+    }
+
+    fn background(area: Rect) -> Paragraph<'static> {
+        let lorem_ipsum = lipsum(area.area() as usize / 5);
+        Paragraph::new(lorem_ipsum)
+            .wrap(Wrap { trim: false })
+            .dark_gray()
+    }
+
+    fn popup_widget() -> Popup<'static, Text<'static>> {
+        Popup::new(
+            "Popup",
+            Text::from_iter([
+                "q: exit",
+                "r: reset",
+                "j: move down",
+                "k: move up",
+                "h: move left",
+                "l: move right",
+            ]),
+        )
+        .style(Style::new().white().on_blue())
+    }
+
+    /// Status bar at the bottom of the screen
+    ///
+    /// Must be called after rendering the popup widget as it relies on the popup area being set
+    fn status_bar(&self) -> Paragraph<'static> {
+        let popup_area = self.popup.area().unwrap_or_default();
+        let text = format!("Popup area: {popup_area:?}");
+        Paragraph::new(text).style(Style::new().white().on_black())
+    }
+
+    fn handle_events(&mut self) -> Result<()> {
+        match event::read()? {
+            Event::Key(event) => self.handle_key_event(event),
+            Event::Mouse(event) => self.handle_mouse_event(event),
+            _ => (),
+        };
+        Ok(())
+    }
+
+    fn handle_key_event(&mut self, event: KeyEvent) {
+        if event.kind != KeyEventKind::Press {
+            return;
+        }
+        match event.code {
+            KeyCode::Char('q') | KeyCode::Esc => self.should_exit = true,
+            KeyCode::Char('r') => self.popup = PopupState::default(),
+            // TODO: move handling to PopupState (e.g. move_up, move_down, etc. or move(Move:Up))
+            KeyCode::Char('j') | KeyCode::Down => self.popup.move_by(0, 1),
+            KeyCode::Char('k') | KeyCode::Up => self.popup.move_by(0, -1),
+            KeyCode::Char('h') | KeyCode::Left => self.popup.move_by(-1, 0),
+            KeyCode::Char('l') | KeyCode::Right => self.popup.move_by(1, 0),
+            _ => {}
         }
     }
-    restore_terminal()?;
-    Ok(())
-}
 
-fn render(frame: &mut Frame<'_>, popup_state: &mut PopupState) {
-    let area = frame.size();
-    let layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(0), Constraint::Length(1)])
-        .split(area);
-    let (background_area, status_area) = (layout[0], layout[1]);
-    let lorem_ipsum = lipsum(area.area() as usize / 5);
-    let background = Paragraph::new(lorem_ipsum)
-        .wrap(Wrap { trim: false })
-        .dark_gray();
-    frame.render_widget(background, background_area);
-    let body = Text::from(vec![
-        "q: exit".into(),
-        "r: reset".into(),
-        "j: move down".into(),
-        "k: move up".into(),
-        "h: move left".into(),
-        "l: move right".into(),
-    ]);
-    let popup = Popup::new("Popup", body).style(Style::new().white().on_blue());
-    frame.render_stateful_widget_ref(popup, background_area, popup_state);
-    let text = format!("{area:?}", area = popup_state.area());
-    let status = Paragraph::new(text).style(Style::new().white().on_black());
-    frame.render_widget(status, status_area);
-}
-
-fn handle_events(popup_state: &mut PopupState) -> color_eyre::Result<ControlFlow<()>> {
-    match event::read()? {
-        Event::Key(KeyEvent {
-            kind: KeyEventKind::Press,
-            code,
-            ..
-        }) => {
-            use KeyCode as key;
-            use KeyCode::Char as char;
-            match code {
-                char('q') | key::Esc => return Ok(ControlFlow::Break(())),
-                char('r') => *popup_state = PopupState::default(),
-                char('j') | key::Down => popup_state.move_by(0, 1),
-                char('k') | key::Up => popup_state.move_by(0, -1),
-                char('h') | key::Left => popup_state.move_by(-1, 0),
-                char('l') | key::Right => popup_state.move_by(1, 0),
-                _ => {}
-            }
-        }
-        Event::Mouse(event) => {
-            match event.kind {
-                event::MouseEventKind::Down(MouseButton::Left) => {
-                    popup_state.mouse_down(event.column, event.row);
-                }
-                event::MouseEventKind::Up(MouseButton::Left) => {
-                    popup_state.mouse_up(event.column, event.row);
-                }
-                event::MouseEventKind::Drag(MouseButton::Left) => {
-                    popup_state.mouse_drag(event.column, event.row);
-                }
-                _ => {}
-            };
-        }
-        _ => (),
-    };
-    Ok(ControlFlow::Continue(()))
-}
-
-fn init_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>, color_eyre::eyre::Error> {
-    stdout().execute(EnterAlternateScreen)?;
-    stdout().execute(EnableMouseCapture)?;
-    let terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
-    enable_raw_mode()?;
-    Ok(terminal)
-}
-
-fn restore_terminal() -> Result<(), color_eyre::eyre::Error> {
-    disable_raw_mode()?;
-    stdout().execute(LeaveAlternateScreen)?;
-    stdout().execute(DisableMouseCapture)?;
-    Ok(())
+    fn handle_mouse_event(&mut self, event: MouseEvent) {
+        let popup = &mut self.popup;
+        // TODO: move mouse event handling to PopupState
+        match event.kind {
+            MouseEventKind::Down(MouseButton::Left) => popup.mouse_down(event.column, event.row),
+            MouseEventKind::Up(MouseButton::Left) => popup.mouse_up(event.column, event.row),
+            MouseEventKind::Drag(MouseButton::Left) => popup.mouse_drag(event.column, event.row),
+            _ => {}
+        };
+    }
 }

--- a/examples/terminal/mod.rs
+++ b/examples/terminal/mod.rs
@@ -1,0 +1,40 @@
+use std::io::{stdout, Stdout};
+
+use color_eyre::{config::HookBuilder, Result};
+use ratatui::{
+    crossterm::{
+        event::{DisableMouseCapture, EnableMouseCapture},
+        execute,
+        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    },
+    prelude::{CrosstermBackend, Terminal},
+};
+
+pub fn init() -> Result<Terminal<CrosstermBackend<Stdout>>> {
+    install_error_hooks()?;
+    execute!(stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+    let terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+    enable_raw_mode()?;
+    Ok(terminal)
+}
+
+pub fn restore() -> Result<()> {
+    disable_raw_mode()?;
+    execute!(stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
+    Ok(())
+}
+
+fn install_error_hooks() -> Result<()> {
+    let (panic_hook, eyre_hook) = HookBuilder::default().into_hooks();
+    let panic_hook = panic_hook.into_panic_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let _ = restore();
+        panic_hook(panic_info);
+    }));
+    let eyre_hook = eyre_hook.into_eyre_hook();
+    color_eyre::eyre::set_hook(Box::new(move |error| {
+        let _ = restore();
+        eyre_hook(error)
+    }))?;
+    Ok(())
+}


### PR DESCRIPTION
- Move terminal setup / restore and error handling to module
- Smaller more focused methods
- Extract App struct for state example
