### PR TITLE
feat(mouse): add PopupState::handle_mouse_event()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.features": ["crossterm"]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +331,12 @@ dependencies = [
  "rand",
  "rand_chacha",
 ]
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -692,6 +707,7 @@ dependencies = [
  "color-eyre",
  "derive-getters",
  "derive_setters",
+ "document-features",
  "lipsum",
  "ratatui",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,20 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.docs.rs]
+all-features = true
+# see https://doc.rust-lang.org/nightly/rustdoc/scraped-examples.html
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = []
+
+## Enables processing crossterm mouse events using [`PopupState::handle_mouse_event`]
+crossterm = ["ratatui/crossterm"]
+
 [dependencies]
+document-features = "0.2.0"
 derive-getters = "0.4.0"
 derive_setters = "0.1.6"
 ratatui = { version = "0.27.0", features = ["unstable-widget-ref"] }
@@ -24,3 +37,8 @@ pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
 unwrap_used = "warn"
 expect_used = "warn"
+
+[[example]]
+name = "state"
+required-features = ["crossterm"]
+doc-scrape-examples = true        # applies to all examples, not just this one

--- a/bacon.toml
+++ b/bacon.toml
@@ -16,28 +16,50 @@ command = ["cargo", "check", "--all-targets", "--color", "always"]
 need_stdout = false
 
 [jobs.clippy]
-command = [
-    "cargo", "clippy",
-    "--all-targets",
-    "--color", "always",
-]
+command = ["cargo", "clippy", "--all-targets", "--color", "always"]
 need_stdout = false
 
 [jobs.test]
 command = [
-    "cargo", "test", "--color", "always",
-    "--", "--color", "always", # see https://github.com/Canop/bacon/issues/124
+    "cargo",
+    "test",
+    "--color",
+    "always",
+    "--",
+    "--color",
+    "always",  # see https://github.com/Canop/bacon/issues/124
 ]
 need_stdout = true
 
 [jobs.doc]
-command = ["cargo", "doc", "--color", "always", "--no-deps"]
+command = [
+    "cargo",
+    "+nightly",
+    "doc",
+    "-Zunstable-options",
+    "-Zrustdoc-scrape-examples",
+    "--all-features",
+    "--color",
+    "always",
+    "--no-deps",
+]
 need_stdout = false
 
 # If the doc compiles, then it opens in your browser and bacon switches
 # to the previous job
 [jobs.doc-open]
-command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+command = [
+    "cargo",
+    "+nightly",
+    "doc",
+    "-Zunstable-options",
+    "-Zrustdoc-scrape-examples",
+    "--all-features",
+    "--color",
+    "always",
+    "--no-deps",
+    "--open",
+]
 need_stdout = false
 on_success = "back" # so that we don't open the browser at each change
 
@@ -47,8 +69,10 @@ on_success = "back" # so that we don't open the browser at each change
 # properly parsed.
 [jobs.run]
 command = [
-    "cargo", "run",
-    "--color", "always",
+    "cargo",
+    "run",
+    "--color",
+    "always",
     # put launch parameters for your program behind a `--` separator
 ]
 need_stdout = true

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -1,9 +1,7 @@
 use color_eyre::Result;
 use lipsum::lipsum;
 use ratatui::{
-    crossterm::event::{
-        self, Event, KeyCode, KeyEvent, KeyEventKind, MouseButton, MouseEvent, MouseEventKind,
-    },
+    crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
     prelude::{Constraint, Frame, Layout, Rect, Style, Stylize, Text},
     widgets::{Paragraph, Wrap},
 };
@@ -78,7 +76,7 @@ impl App {
     fn handle_events(&mut self) -> Result<()> {
         match event::read()? {
             Event::Key(event) => self.handle_key_event(event),
-            Event::Mouse(event) => self.handle_mouse_event(event),
+            Event::Mouse(event) => self.popup.handle_mouse_event(event),
             _ => (),
         };
         Ok(())
@@ -98,16 +96,5 @@ impl App {
             KeyCode::Char('l') | KeyCode::Right => self.popup.move_by(1, 0),
             _ => {}
         }
-    }
-
-    fn handle_mouse_event(&mut self, event: MouseEvent) {
-        let popup = &mut self.popup;
-        // TODO: move mouse event handling to PopupState
-        match event.kind {
-            MouseEventKind::Down(MouseButton::Left) => popup.mouse_down(event.column, event.row),
-            MouseEventKind::Up(MouseButton::Left) => popup.mouse_up(event.column, event.row),
-            MouseEventKind::Drag(MouseButton::Left) => popup.mouse_drag(event.column, event.row),
-            _ => {}
-        };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@
 //! ```
 //!
 //! ![demo](https://vhs.charm.sh/vhs-q5Kz0QP3zmrBlQ6dofjMh.gif)
+//!
+//! # Feature flags
+#![doc = document_features::document_features!()]
 
 mod popup;
 mod state;

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -8,9 +8,8 @@ use ratatui::{
 
 /// Configuration for a popup.
 ///
-/// This struct is used to configure a [`PopupWidget`]. It can be created using
-/// [`Popup::new`](Popup::new). Convert it into a Ratatui widget using
-/// [`Popup::to_widget`](Popup::to_widget).
+/// This struct is used to configure a [`Popup`]. It can be created using
+/// [`Popup::new`](Popup::new).
 ///
 /// # Example
 ///


### PR DESCRIPTION
Converts a crossterm mouse event into mouse movement. Requires the
`crossterm` feature to be enabled.

```rust
if let Event::Mouse(event) = event::read()? {
    popup_state.handle_mouse_event(event);
}
```
